### PR TITLE
[Reviewer: RKD] Change route headers for GR w/o split horizon

### DIFF
--- a/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/aka_initial_register.xml
+++ b/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/aka_initial_register.xml
@@ -14,7 +14,7 @@
 	P-Charging-Vector: icid-value=d4511351a7e24c5ff16243bac827fc3f
 	Supported: path
 	To: <sip:[field0]@[home_domain]>
-	Route: <sip:icscf.sprout.[home_domain];lr>
+	Route: <sip:icscf@[remote_ip];lr>
 	Max-Forwards: 70
 	Contact: sip:[field0]@[local_ip]:[local_port]
 	Call-ID: [call_id]
@@ -45,7 +45,7 @@
 	P-Charging-Vector: icid-value=d4511351a7e24c5ff16243bac827fc3f
 	Supported: path
 	To: <sip:[field0]@[home_domain]>
-	Route: <sip:icscf.sprout.[home_domain];lr>
+	Route: <sip:icscf@[remote_ip];lr>
 	Max-Forwards: 70
 	Contact: sip:[field0]@[local_ip]:[local_port]
 	Call-ID: [call_id]

--- a/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/aka_re_register.xml
+++ b/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/aka_re_register.xml
@@ -14,7 +14,7 @@
 	P-Charging-Vector: icid-value=d4511351a7e24c5ff16243bac827fc3f
 	Supported: path
 	To: <sip:[field0]@[home_domain]>
-	Route: <sip:icscf.sprout.[home_domain];lr>
+	Route: <sip:icscf@[remote_ip];lr>
 	Max-Forwards: 70
 	Contact: sip:[field0]@[local_ip]:[local_port]
 	Call-ID: [call_id]

--- a/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/caller.xml
+++ b/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/caller.xml
@@ -10,7 +10,7 @@
       To: <sip:[field1]@[home_domain]>
       CSeq: 1 INVITE
       Expires: 180
-      Route: <sip:scscf.sprout.[home_domain]:5054;transport=tcp;lr;orig>
+      Route: <sip:scscf@[remote_ip]:5054;transport=tcp;lr;orig>
       Content-Length: [len]
       Call-Info: <sip:[local_ip]:[local_port]>;method="NOTIFY;Event=telephone-event;Duration=2000"
       P-Charging-Function-Addresses: ccf=0.0.0.0

--- a/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/digest_register.xml
+++ b/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/digest_register.xml
@@ -14,7 +14,7 @@
 	P-Charging-Vector: icid-value=d4511351a7e24c5ff16243bac827fc3f
 	Supported: path
 	To: <sip:[field0]@[home_domain]>
-	Route: <sip:icscf.sprout.[home_domain];lr>
+	Route: <sip:icscf@[remote_ip];lr>
 	Max-Forwards: 70
 	Contact: sip:[field0]@[local_ip]:[local_port]
 	Call-ID: [call_id]
@@ -44,7 +44,7 @@
 	P-Charging-Vector: icid-value=d4511351a7e24c5ff16243bac827fc3f
 	Supported: path
 	To: <sip:[field0]@[home_domain]>
-	Route: <sip:icscf.sprout.[home_domain];lr>
+	Route: <sip:icscf@[remote_ip];lr>
 	Max-Forwards: 70
 	Contact: sip:[field0]@[local_ip]:[local_port]
 	Call-ID: [call_id]


### PR DESCRIPTION
Tweak because `icscf.sprout.<domain>` and `scscf.sprout.<domain>` don't resolve on GR deployments with sites residing in different DNS zones.