### PR TITLE
Change route URIs to use the service parameter

### DIFF
--- a/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/aka_initial_register.xml
+++ b/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/aka_initial_register.xml
@@ -14,7 +14,7 @@
 	P-Charging-Vector: icid-value=d4511351a7e24c5ff16243bac827fc3f
 	Supported: path
 	To: <sip:[field0]@[home_domain]>
-	Route: <sip:icscf@[remote_ip];lr>
+	Route: <sip:[remote_ip];lr;service=icscf>
 	Max-Forwards: 70
 	Contact: sip:[field0]@[local_ip]:[local_port]
 	Call-ID: [call_id]
@@ -45,7 +45,7 @@
 	P-Charging-Vector: icid-value=d4511351a7e24c5ff16243bac827fc3f
 	Supported: path
 	To: <sip:[field0]@[home_domain]>
-	Route: <sip:icscf@[remote_ip];lr>
+	Route: <sip:[remote_ip];lr;service=icscf>
 	Max-Forwards: 70
 	Contact: sip:[field0]@[local_ip]:[local_port]
 	Call-ID: [call_id]

--- a/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/aka_re_register.xml
+++ b/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/aka_re_register.xml
@@ -14,7 +14,7 @@
 	P-Charging-Vector: icid-value=d4511351a7e24c5ff16243bac827fc3f
 	Supported: path
 	To: <sip:[field0]@[home_domain]>
-	Route: <sip:icscf@[remote_ip];lr>
+	Route: <sip:[remote_ip];lr;service=icscf>
 	Max-Forwards: 70
 	Contact: sip:[field0]@[local_ip]:[local_port]
 	Call-ID: [call_id]

--- a/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/caller.xml
+++ b/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/caller.xml
@@ -10,7 +10,7 @@
       To: <sip:[field1]@[home_domain]>
       CSeq: 1 INVITE
       Expires: 180
-      Route: <sip:scscf@[remote_ip]:5054;transport=tcp;lr;orig>
+      Route: <sip:[remote_ip]:5054;transport=tcp;lr;orig;service=scscf>
       Content-Length: [len]
       Call-Info: <sip:[local_ip]:[local_port]>;method="NOTIFY;Event=telephone-event;Duration=2000"
       P-Charging-Function-Addresses: ccf=0.0.0.0
@@ -89,7 +89,7 @@
 
     ]]>
   </send>
-  
+
   <recv response="200">
   </recv>
 
@@ -148,11 +148,11 @@
 
        - we use 201, not 200, as the UPDATE response code (this is fine because
          it's still in the 2xx class)
- 
+
        - we expect the UPDATE response as an optional message in the two places
          we've seen it appear, before and after the 180 Ringing
   -->
-  
+
   <recv response="201" optional="true">
   </recv>
 

--- a/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/digest_register.xml
+++ b/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/digest_register.xml
@@ -14,7 +14,7 @@
 	P-Charging-Vector: icid-value=d4511351a7e24c5ff16243bac827fc3f
 	Supported: path
 	To: <sip:[field0]@[home_domain]>
-	Route: <sip:icscf@[remote_ip];lr>
+	Route: <sip:[remote_ip];lr;service=icscf>
 	Max-Forwards: 70
 	Contact: sip:[field0]@[local_ip]:[local_port]
 	Call-ID: [call_id]
@@ -44,7 +44,7 @@
 	P-Charging-Vector: icid-value=d4511351a7e24c5ff16243bac827fc3f
 	Supported: path
 	To: <sip:[field0]@[home_domain]>
-	Route: <sip:icscf@[remote_ip];lr>
+	Route: <sip:[remote_ip];lr;service=icscf>
 	Max-Forwards: 70
 	Contact: sip:[field0]@[local_ip]:[local_port]
 	Call-ID: [call_id]


### PR DESCRIPTION
The stress scripts that emulate a P-CSCF don't currently work with the master version of sprout. This is because the scripts put the name of the desired service (icscf/scscf) in the user-part of the Route URI. 

This doesn't place nicely with the refactoring work done under https://github.com/Metaswitch/sprout/pull/1634, which made the existing authentication, registrar and subscription modules into sproutlets. The problem is that to route between each other the new sproutlets manipulate the top route header but leave the user-part unchanged. But if the desired sproutlet is in the user-part, the target sproutlet never gets updated and the sproutlets ends up forwarding the request to itself. 

This PR implements a workaround - which is to put the desired service in the `service` parameter. This parameter *is* updated when routing between the new sproutlets, so there is no routing loop. 

Tested live. 