### PR TITLE
[No reviewer] SIPp timeouts, controllable errors, and better failures

### DIFF
--- a/clearwater-sip-stress-coreonly.root/usr/share/clearwater/bin/run_stress
+++ b/clearwater-sip-stress-coreonly.root/usr/share/clearwater/bin/run_stress
@@ -88,6 +88,8 @@ parser.add_argument('--aka', help='Use AKAv1 authentication, not SIP Digest', ac
 parser.add_argument('--ignore-initial-reg-failures', help="Don't exit if some initial REGISTER messages fail", action='store_const', const=True, default=False)
 parser.add_argument('--single', help="Make one REGISTER, pause for 2 minutes, then make one call. Ignores subscriber count and duration", action='store_const', const=True, default=False)
 parser.add_argument('--base-number', help='First number in the number range for subscribers (default: 2010000000)', type=int, default=2010000000)
+parser.add_argument('--with-errors', help='10% of calls should get error responses', action='store_const', const=True, default=False)
+parser.add_argument('--messages', help='Use MESSAGE flows instead of INVITE flows', action='store_const', const=True, default=False)
 
 args = parser.parse_args()
 
@@ -178,8 +180,15 @@ re_reg_cmd = [SIPP_BIN,
               "-r", str(RPS),
               "-m", str(REG_MAX)] + common_originating_args + [args.icscf_target]
 
+if args.messages:
+    caller_file = "message_sender.xml"
+    callee_file = "error_message_receiver.xml" if args.with_errors else "message_receiver.xml"
+else:
+    caller_file = "caller.xml"
+    callee_file = "error_callee.xml" if args.with_errors else "callee.xml"
+
 caller_cmd = [SIPP_BIN,
-              "-sf", SCRIPTS_DIR + "caller.xml",
+              "-sf", SCRIPTS_DIR + caller_file,
               "-inf", invite_csv.name,
               "-trace_err", "-error_file", CALLER_ERRORS,
               "-trace_stat", "-stf", CALLER_STATS,
@@ -190,8 +199,9 @@ caller_cmd = [SIPP_BIN,
 # Callee must listen on port 5082, because this is what's in the Path header in
 # register.xml.
 
+
 callee_cmd = [SIPP_BIN,
-              "-sf", SCRIPTS_DIR + "callee.xml",
+              "-sf", SCRIPTS_DIR + callee_file,
               "-trace_err", "-error_file", CALLEE_ERRORS,
               "-p", "5082",
               "-m", str(CALL_MAX)] + common_args
@@ -262,9 +272,10 @@ with open(CALLER_STATS) as f:
     # Iterate over the whole file so that `row` is set to the last row
     for row in r:
         pass
-    hours, mins, secs, nanoseconds = map(int, row['ResponseTime1(C)'].split(":"))
-    rtt = (nanoseconds / 1000.0) + (secs * 1000.0)
-    print """
+    if not args.messages:
+        hours, mins, secs, nanoseconds = map(int, row['ResponseTime1(C)'].split(":"))
+        rtt = (nanoseconds / 1000.0) + (secs * 1000.0)
+        print """
 Elapsed time: {}
 Start: {}
 End: {}
@@ -281,26 +292,45 @@ Average time from INVITE to 180 Ringing: {} ms
 # of calls with 20-200ms from INVITE to 180 Ringing: {} ({}%)
 # of calls with 200-2000ms from INVITE to 180 Ringing: {} ({}%)
 # of calls with 2000+ms from INVITE to 180 Ringing: {} ({}%)""".format(
-    row['ElapsedTime(C)'],
-    start_time,
-    end_time,
-    row['TotalCallCreated'],
-    row['SuccessfulCall(C)'],
-    100* float(row['SuccessfulCall(C)']) / float(row['TotalCallCreated']),
-    row['FailedCall(C)'],
-    100* float(row['FailedCall(C)']) / float(row['TotalCallCreated']),
-    row['Retransmissions(C)'],
-    rtt,
-    row['ResponseTimeRepartition1_<2'],
-    100* float(row['ResponseTimeRepartition1_<2']) / float(row['TotalCallCreated']),
-    row['ResponseTimeRepartition1_<20'],
-    100* float(row['ResponseTimeRepartition1_<20']) / float(row['TotalCallCreated']),
-    row['ResponseTimeRepartition1_<200'],
-    100* float(row['ResponseTimeRepartition1_<200']) / float(row['TotalCallCreated']),
-    row['ResponseTimeRepartition1_<2000'],
-    100* float(row['ResponseTimeRepartition1_<2000']) / float(row['TotalCallCreated']),
-    row['ResponseTimeRepartition1_>=2000'],
-    100* float(row['ResponseTimeRepartition1_>=2000']) / float(row['TotalCallCreated']))
+        row['ElapsedTime(C)'],
+        start_time,
+        end_time,
+        row['TotalCallCreated'],
+        row['SuccessfulCall(C)'],
+        100* float(row['SuccessfulCall(C)']) / float(row['TotalCallCreated']),
+        row['FailedCall(C)'],
+        100* float(row['FailedCall(C)']) / float(row['TotalCallCreated']),
+        row['Retransmissions(C)'],
+        rtt,
+        row['ResponseTimeRepartition1_<2'],
+        100* float(row['ResponseTimeRepartition1_<2']) / float(row['TotalCallCreated']),
+        row['ResponseTimeRepartition1_<20'],
+        100* float(row['ResponseTimeRepartition1_<20']) / float(row['TotalCallCreated']),
+        row['ResponseTimeRepartition1_<200'],
+        100* float(row['ResponseTimeRepartition1_<200']) / float(row['TotalCallCreated']),
+        row['ResponseTimeRepartition1_<2000'],
+        100* float(row['ResponseTimeRepartition1_<2000']) / float(row['TotalCallCreated']),
+        row['ResponseTimeRepartition1_>=2000'],
+        100* float(row['ResponseTimeRepartition1_>=2000']) / float(row['TotalCallCreated']))
+    else:
+        print """
+Elapsed time: {}
+Start: {}
+End: {}
+
+Total MESSAGE flows: {}
+Successful MESSAGE flows: {} ({}%)
+Failed MESSAGE flows: {} ({}%)
+""".format(
+        row['ElapsedTime(C)'],
+        start_time,
+        end_time,
+        row['TotalCallCreated'],
+        row['SuccessfulCall(C)'],
+        100* float(row['SuccessfulCall(C)']) / float(row['TotalCallCreated']),
+        row['FailedCall(C)'],
+        100* float(row['FailedCall(C)']) / float(row['TotalCallCreated']))
+ 
 
 if not args.single: #  we didn't do re-registrations in this case, so won't have any stats
     with open(RE_REG_STATS) as f:

--- a/clearwater-sip-stress-coreonly.root/usr/share/clearwater/bin/run_stress
+++ b/clearwater-sip-stress-coreonly.root/usr/share/clearwater/bin/run_stress
@@ -119,6 +119,12 @@ registers = range(SUB_START, SUB_END)
 callers = range(SUB_START, SUB_END, 2)
 callees = range(SUB_START + 1, SUB_END, 2)
 
+# Convert the duration into seconds for a SIPp timeout, and add a safety factor
+sipp_timeout = "{}s".format((args.duration * 60) + 120)
+
+initial_reg_duration = args.subscriber_count/args.initial_reg_rate
+initial_reg_timeout = "{}s".format(initial_reg_duration + 120)
+
 # Randomly shuffle the order of registers and calls to reduce the risk of any cache issues
 shuffle(registers)
 shuffle(callers)
@@ -149,6 +155,7 @@ common_args = ["-default_behaviors", "all,-bye",
                # Keep calls alive when we reconnect, and try and reconnect very quickly (1ms).
                "-reconnect_close", "false",
                "-reconnect_sleep", "1",
+               "-recv_timeout", "20s",
                "-t", "t1"]
 
 common_originating_args = common_args + ["-key", "home_domain", args.domain]
@@ -164,6 +171,7 @@ initial_reg_cmd = [SIPP_BIN,
                    "-sf", SCRIPTS_DIR + initial_reg_xml,
                    "-inf", register_csv.name,
                    "-trace_err", "-error_file", INITIAL_REG_ERRORS,
+                   "-timeout", initial_reg_timeout,
                    "-r", str(args.initial_reg_rate),
                    "-m", str(args.subscriber_count)] + common_originating_args + [args.icscf_target]
 
@@ -172,6 +180,7 @@ re_reg_cmd = [SIPP_BIN,
               "-inf", register_csv.name,
               "-trace_err", "-error_file", RE_REG_ERRORS,
               "-trace_stat", "-stf", RE_REG_STATS,
+              "-timeout", sipp_timeout,
               "-r", str(RPS),
               "-m", str(REG_MAX)] + common_originating_args + [args.icscf_target]
 
@@ -180,6 +189,7 @@ caller_cmd = [SIPP_BIN,
               "-inf", invite_csv.name,
               "-trace_err", "-error_file", CALLER_ERRORS,
               "-trace_stat", "-stf", CALLER_STATS,
+              "-timeout", sipp_timeout,
               "-r", str(CPS),
               "-d", str(args.call_length * 1000),
               "-m", str(CALL_MAX)] + common_originating_args + [args.scscf_target]
@@ -190,13 +200,14 @@ caller_cmd = [SIPP_BIN,
 callee_cmd = [SIPP_BIN,
               "-sf", SCRIPTS_DIR + "callee.xml",
               "-trace_err", "-error_file", CALLEE_ERRORS,
+              "-timeout", sipp_timeout,
               "-p", "5082",
               "-m", str(CALL_MAX)] + common_args
 
 # Do initial registrations as quickly as possible for test setup - this is an
 # unrealistic load profile, so no need for measurements yet.
 
-print "Starting initial registration, will take {} seconds".format(args.subscriber_count/args.initial_reg_rate)
+print "Starting initial registration, will take {} seconds".format(initial_reg_duration)
 
 if args.sipp_output:
     proc = Popen(initial_reg_cmd)

--- a/clearwater-sip-stress-coreonly.root/usr/share/clearwater/bin/run_stress
+++ b/clearwater-sip-stress-coreonly.root/usr/share/clearwater/bin/run_stress
@@ -80,6 +80,7 @@ parser.add_argument('--ignore-initial-reg-failures', help="Don't exit if some in
 parser.add_argument('--single', help="Make one REGISTER, pause for 2 minutes, then make one call. Ignores subscriber count and duration", action='store_const', const=True, default=False)
 parser.add_argument('--base-number', help='First number in the number range for subscribers (default: 2010000000)', type=int, default=2010000000)
 parser.add_argument('--log-prefix', help='Prefix for log files (default: the process ID)', type=int, default=os.getpid())
+parser.add_argument('--target-latency', help='Target average latency.  The script will fail if the mean time from INVITE to 180 Ringing is higher than this.', type=int)
 
 args = parser.parse_args()
 
@@ -309,7 +310,7 @@ Average time from INVITE to 180 Ringing: {} ms
     if int(row['FailedCall(C)'] > 0:
         rc = 1
 
-    if rtt > 150:
+    if args.target_latency and rtt > args.target_latency:
         rc = 2
 
 if not args.single: #  we didn't do re-registrations in this case, so won't have any stats

--- a/clearwater-sip-stress-coreonly.root/usr/share/clearwater/bin/run_stress
+++ b/clearwater-sip-stress-coreonly.root/usr/share/clearwater/bin/run_stress
@@ -55,15 +55,6 @@ class SIPpstats(csv.excel):
 SIPP_BIN = "/usr/share/clearwater/bin/sipp_coreonly"
 SCRIPTS_DIR = "/usr/share/clearwater/sip-stress/"
 
-LOG_PREFIX = "/var/log/clearwater-sip-stress/{}_".format(os.getpid())
-
-INITIAL_REG_ERRORS = LOG_PREFIX + "initial_reg_errors.log"
-RE_REG_ERRORS = LOG_PREFIX + "re_reg_errors.log"
-CALLER_ERRORS = LOG_PREFIX + "caller_errors.log"
-CALLEE_ERRORS = LOG_PREFIX + "callee_errors.log"
-RE_REG_STATS  = LOG_PREFIX + "re_reg_stats.log"
-CALLER_STATS  = LOG_PREFIX + "caller_stats.log"
-
 BHCA = 1.3
 
 # Call attempts are split 50/50 between originating calls and terminating
@@ -88,8 +79,19 @@ parser.add_argument('--aka', help='Use AKAv1 authentication, not SIP Digest', ac
 parser.add_argument('--ignore-initial-reg-failures', help="Don't exit if some initial REGISTER messages fail", action='store_const', const=True, default=False)
 parser.add_argument('--single', help="Make one REGISTER, pause for 2 minutes, then make one call. Ignores subscriber count and duration", action='store_const', const=True, default=False)
 parser.add_argument('--base-number', help='First number in the number range for subscribers (default: 2010000000)', type=int, default=2010000000)
+parser.add_argument('--log-prefix', help='Prefix for log files (default: the process ID)', type=int, default=os.getpid())
 
 args = parser.parse_args()
+
+LOG_PREFIX = "/var/log/clearwater-sip-stress/{}_".format(args.log_prefix)
+
+INITIAL_REG_ERRORS = LOG_PREFIX + "initial_reg_errors.log"
+RE_REG_ERRORS = LOG_PREFIX + "re_reg_errors.log"
+CALLER_ERRORS = LOG_PREFIX + "caller_errors.log"
+CALLEE_ERRORS = LOG_PREFIX + "callee_errors.log"
+RE_REG_STATS  = LOG_PREFIX + "re_reg_stats.log"
+CALLER_STATS  = LOG_PREFIX + "caller_stats.log"
+
 
 if args.icscf_target is None:
     args.icscf_target = "sprout.{}:5052".format(args.domain)
@@ -257,6 +259,8 @@ callee_proc.kill()
 print "Test complete"
 end_time = datetime.now()
 
+rc = 0
+
 with open(CALLER_STATS) as f:
     r = DictReader(f, dialect=SIPpstats())
     # Iterate over the whole file so that `row` is set to the last row
@@ -302,6 +306,12 @@ Average time from INVITE to 180 Ringing: {} ms
     row['ResponseTimeRepartition1_>=2000'],
     100* float(row['ResponseTimeRepartition1_>=2000']) / float(row['TotalCallCreated']))
 
+    if int(row['FailedCall(C)'] > 0:
+        rc = 1
+
+    if rtt > 150:
+        rc = 2
+
 if not args.single: #  we didn't do re-registrations in this case, so won't have any stats
     with open(RE_REG_STATS) as f:
         r = DictReader(f, dialect=SIPpstats())
@@ -326,4 +336,9 @@ Average time from REGISTER to 200 OK: {} ms""".format(
         row['Retransmissions(C)'],
         rtt)
 
+        if int(row['FailedCall(C)'] > 0:
+            rc = 3
+
 print "\nLog files at {}*".format(LOG_PREFIX)
+
+sys.exit(rc)

--- a/clearwater-sip-stress-coreonly.root/usr/share/clearwater/bin/run_stress
+++ b/clearwater-sip-stress-coreonly.root/usr/share/clearwater/bin/run_stress
@@ -41,6 +41,7 @@ from sys import exit
 from time import sleep
 from tempfile import NamedTemporaryFile
 import os
+import sys
 
 # Set up a CSV Dialect subclass to handle the semicolon-separated stats files
 # SIPp produces
@@ -79,9 +80,9 @@ parser.add_argument('--aka', help='Use AKAv1 authentication, not SIP Digest', ac
 parser.add_argument('--ignore-initial-reg-failures', help="Don't exit if some initial REGISTER messages fail", action='store_const', const=True, default=False)
 parser.add_argument('--single', help="Make one REGISTER, pause for 2 minutes, then make one call. Ignores subscriber count and duration", action='store_const', const=True, default=False)
 parser.add_argument('--base-number', help='First number in the number range for subscribers (default: 2010000000)', type=int, default=2010000000)
-parser.add_argument('--with-errors', help='10% of calls should get error responses', action='store_const', const=True, default=False)
+parser.add_argument('--with-errors', help='10%% of calls should get error responses', action='store_const', const=True, default=False)
 parser.add_argument('--messages', help='Use MESSAGE flows instead of INVITE flows', action='store_const', const=True, default=False)
-parser.add_argument('--log-prefix', help='Prefix for log files (default: the process ID)', type=int, default=os.getpid())
+parser.add_argument('--log-prefix', help='Prefix for log files (default: the process ID)', type=str, default=str(os.getpid()))
 parser.add_argument('--target-latency', help='Target average latency.  The script will fail if the mean time from INVITE to 180 Ringing is higher than this.', type=int)
 
 args = parser.parse_args()
@@ -328,6 +329,10 @@ Average time from INVITE to 180 Ringing: {} ms
         100* float(row['ResponseTimeRepartition1_<2000']) / float(row['TotalCallCreated']),
         row['ResponseTimeRepartition1_>=2000'],
         100* float(row['ResponseTimeRepartition1_>=2000']) / float(row['TotalCallCreated']))
+    
+        if args.target_latency and rtt > args.target_latency:
+            rc = 2
+
     else:
         print """
 Elapsed time: {}
@@ -348,11 +353,8 @@ Failed MESSAGE flows: {} ({}%)
         100* float(row['FailedCall(C)']) / float(row['TotalCallCreated']))
  
 
-    if int(row['FailedCall(C)'] > 0:
+    if int(row['FailedCall(C)']) > 0:
         rc = 1
-
-    if args.target_latency and rtt > args.target_latency:
-        rc = 2
 
 if not args.single: #  we didn't do re-registrations in this case, so won't have any stats
     with open(RE_REG_STATS) as f:
@@ -378,7 +380,7 @@ Average time from REGISTER to 200 OK: {} ms""".format(
         row['Retransmissions(C)'],
         rtt)
 
-        if int(row['FailedCall(C)'] > 0:
+        if int(row['FailedCall(C)']) > 0:
             rc = 3
 
 print "\nLog files at {}*".format(LOG_PREFIX)

--- a/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/error_callee.xml
+++ b/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/error_callee.xml
@@ -138,6 +138,10 @@
     ]]>
   </send>
 
+  <nop next="error" chance="0.10" />
+
+  <label id="success"/>
+
   <!-- Precondition exchange has completed, so start ringing -->
   <send>
     <![CDATA[
@@ -163,9 +167,6 @@
 
   <pause milliseconds="2300" />
 
-  <nop next="error" chance="0.10">
-
-  <label id="success"/>
   <send retrans="500">
     <![CDATA[
       SIP/2.0 200 OK
@@ -193,12 +194,12 @@
     ]]>
   </send>
 
-  <nop next="skip_error">
+  <nop next="skip_error" />
 
   <label id="error"/>
   <send retrans="500">
     <![CDATA[
-      SIP/2.0 404 Not Found
+      SIP/2.0 404 SIPp-Generated Not Found
       [last_Call-ID:]
       [$invite_cseq]
       [last_From:]
@@ -222,7 +223,11 @@
     ]]>
   </send>
 
-  <nop next="end">
+  <recv request="ACK"
+        crlf="true">
+  </recv>
+
+  <nop next="end" />
   
   <label id="skip_error"/>
 

--- a/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/error_callee.xml
+++ b/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/error_callee.xml
@@ -1,0 +1,260 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<scenario name="Clearwater callee">
+  <recv request="INVITE" rrs="true" crlf="true">
+    <action>
+      <!-- Save off our identity for later use -->
+      <ereg regexp=".*<sip:(.*)@(.*)>.*" search_in="hdr" header="To:" check_it="true" assign_to="_,dn,home_domain" />
+    </action>
+  </recv>
+
+  <nop>
+    <action>
+      <!-- Save off the per-transaction headers, for use on the eventual 180 Ringing and 200 OK -->
+      <assignstr assign_to="invite_cseq" value="[last_Cseq:]" />
+      <assignstr assign_to="invite_via" value="[last_Via:]" />
+    </action>
+  </nop>
+
+  <send>
+    <![CDATA[
+      SIP/2.0 183 Session Progress
+      [last_Call-ID:]
+      [last_CSeq:]
+      [last_From:]
+      [last_To:];tag=[pid]SIPpTag01[call_number]
+      [last_Via:]
+      Server: SIP/2.0
+      RSeq: 462555543
+      Content-Length: [len]
+      Require: precondition, 100rel
+      [last_P-Charging-Vector:]
+      P-Asserted-Identity: sip:[$dn]@[$home_domain]
+      Contact: <sip:[$dn]@[local_ip]:[local_port];transport=[transport]>;+g.3gpp.icsi-ref="urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel";video
+      Record-Route: <sip:[local_ip]:[local_port];transport=[transport];lr>
+      [last_Record-Route:]
+      Content-Type: application/sdp
+      Allow: INVITE,ACK,OPTIONS,CANCEL,BYE,UPDATE,INFO,REFER,NOTIFY,MESSAGE,PRACK
+      P-Access-Network-Info: 3GPP-E-UTRAN-FDD;utran-cell-id-3gpp=0010100011a2d051
+      User-Agent: BBBBBBB IMS 0.0
+
+      v=0
+      o=BBBBBBB-IMS-UE 63153200187759 63153200187759 IN IP4 [local_ip]
+      s=-
+      c=IN IP4 [local_ip]
+      t=0 0
+      m=audio 16406 RTP/AVP 116 111
+      b=AS:41
+      b=RS:375
+      b=RR:1125
+      a=inactive
+      a=rtpmap:116 AMR-WB/16000/1
+      a=rtpmap:111 telephone-event/16000
+      a=fmtp:116 mode-change-capability=2;max-red=220
+      a=fmtp:111 0-15
+      a=curr:qos local none
+      a=curr:qos remote none
+      a=des:qos mandatory local sendrecv
+      a=des:qos mandatory remote sendrecv
+      a=conf:qos remote sendrecv
+      a=maxptime:240
+      a=ptime:20
+
+    ]]>
+  </send>
+
+  <recv request="PRACK">
+  </recv>
+
+  <send>
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Call-ID:]
+      [last_CSeq:]
+      [last_From:]
+      [last_To:];tag=[pid]SIPpTag01[call_number]
+      [last_Via:]
+      Server: SIP/2.0
+      Content-Length: 0
+      Supported: 100rel,timer,precondition,histinfo
+      [last_P-Charging-Vector:]
+      Contact: <sip:[$dn]@[local_ip]:[local_port];transport=[transport]>;+g.3gpp.icsi-ref="urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel";video
+      Allow: INVITE,ACK,OPTIONS,CANCEL,BYE,UPDATE,INFO,REFER,NOTIFY,MESSAGE,PRACK
+      P-Access-Network-Info: 3GPP-E-UTRAN-FDD;utran-cell-id-3gpp=0010100011a2d051
+      User-Agent: BBBBBBB IMS 0.0
+
+    ]]>
+  </send>
+
+
+  <recv request="UPDATE">
+  </recv>
+
+  <!-- Use 201 as the response code for the UPDATE, to clearly distinguish it
+       from the 200 OK for the INVITE. -->
+  <send>
+    <![CDATA[
+      SIP/2.0 201 OK
+      [last_Call-ID:]
+      [last_CSeq:]
+      [last_From:]
+      [last_To:];tag=[pid]SIPpTag01[call_number]
+      [last_Via:]
+      Server: SIP/2.0
+      [last_Record-Route:]
+      Content-Length: [len]
+      Supported: 100rel,timer,precondition,histinfo
+      Require: precondition
+      [last_P-Charging-Vector:]
+      Contact: <sip:[$dn]@[local_ip]:[local_port];transport=[transport]>;+g.3gpp.icsi-ref="urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel";video
+      Content-Type: application/sdp
+      Allow: INVITE,ACK,OPTIONS,CANCEL,BYE,UPDATE,INFO,REFER,NOTIFY,MESSAGE,PRACK
+      P-Access-Network-Info: 3GPP-E-UTRAN-FDD;utran-cell-id-3gpp=0010100011a2d051
+      User-Agent: BBBBBBB IMS 0.0
+
+      v=0
+      o=BBBBBBB-IMS-UE 63153200187759 63153200187760 IN IP4 [local_ip]
+      s=-
+      c=IN IP4 [local_ip]
+      t=0 0
+      m=audio 16406 RTP/AVP 116 111
+      b=AS:41
+      b=RS:375
+      b=RR:1125
+      a=sendrecv
+      a=rtpmap:116 AMR-WB/16000/1
+      a=rtpmap:111 telephone-event/16000
+      a=fmtp:116 mode-change-capability=2;max-red=220
+      a=fmtp:111 0-15
+      a=curr:qos local sendrecv
+      a=curr:qos remote sendrecv
+      a=des:qos mandatory local sendrecv
+      a=des:qos mandatory remote sendrecv
+      a=maxptime:240
+      a=ptime:20
+
+    ]]>
+  </send>
+
+  <!-- Precondition exchange has completed, so start ringing -->
+  <send>
+    <![CDATA[
+      SIP/2.0 180 Ringing
+      [last_Call-ID:]
+      [$invite_cseq]
+      [last_From:]
+      [last_To:];tag=[pid]SIPpTag01[call_number]
+      [$invite_via]
+      Server: SIP/2.0
+      Content-Length: 0
+      [last_P-Charging-Vector:]
+      P-Asserted-Identity: sip:[$dn]@[$home_domain]
+      Contact: <sip:[$dn]@[local_ip]:[local_port];transport=[transport]>;+g.3gpp.icsi-ref="urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel";video
+      [last_Record-Route:]
+      Allow: INVITE,ACK,OPTIONS,CANCEL,BYE,UPDATE,INFO,REFER,NOTIFY,MESSAGE,PRACK
+      P-Access-Network-Info: 3GPP-E-UTRAN-FDD;utran-cell-id-3gpp=0010100011a2d051
+      User-Agent: BBBBBBB IMS 5.0
+
+
+    ]]>
+  </send>
+
+  <pause milliseconds="2300" />
+
+  <nop next="error" chance="0.10">
+
+  <label id="success"/>
+  <send retrans="500">
+    <![CDATA[
+      SIP/2.0 200 OK
+      [last_Call-ID:]
+      [$invite_cseq]
+      [last_From:]
+      [last_To:];tag=[pid]SIPpTag01[call_number]
+      [$invite_via]
+      Server: SIP/2.0
+      Content-Length: 0
+      Supported: 100rel,timer,precondition,histinfo
+      Require: timer
+      [last_P-Charging-Vector:]
+      P-Asserted-Identity: sip:[$dn]@[$home_domain]
+      P-Charging-Function-Addresses: ccf=0.0.0.0
+      Contact: <sip:[$dn]@[local_ip]:[local_port];transport=[transport]>;+g.3gpp.icsi-ref="urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel";video
+      [last_Record-Route:]
+      Accept: application/sdp,application/3gpp-ims+xml, application/dtmf-relay
+      Accept-Contact: *;+g.3gpp.icsi-ref="urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel"
+      Session-Expires: 600;refresher=uac
+      Allow: INVITE,ACK,OPTIONS,CANCEL,BYE,UPDATE,INFO,REFER,NOTIFY,MESSAGE,PRACK
+      P-Access-Network-Info: 3GPP-E-UTRAN-FDD;utran-cell-id-3gpp=0010100011a2d051
+      User-Agent: BBBBBBB IMS 5.0
+
+    ]]>
+  </send>
+
+  <nop next="skip_error">
+
+  <label id="error"/>
+  <send retrans="500">
+    <![CDATA[
+      SIP/2.0 404 Not Found
+      [last_Call-ID:]
+      [$invite_cseq]
+      [last_From:]
+      [last_To:];tag=[pid]SIPpTag01[call_number]
+      [$invite_via]
+      Server: SIP/2.0
+      Content-Length: 0
+      Supported: 100rel,timer,precondition,histinfo
+      Require: timer
+      [last_P-Charging-Vector:]
+      P-Asserted-Identity: sip:[$dn]@[$home_domain]
+      P-Charging-Function-Addresses: ccf=0.0.0.0
+      Contact: <sip:[$dn]@[local_ip]:[local_port];transport=[transport]>;+g.3gpp.icsi-ref="urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel";video
+      [last_Record-Route:]
+      Accept: application/sdp,application/3gpp-ims+xml, application/dtmf-relay
+      Accept-Contact: *;+g.3gpp.icsi-ref="urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel"
+      Session-Expires: 600;refresher=uac
+      Allow: INVITE,ACK,OPTIONS,CANCEL,BYE,UPDATE,INFO,REFER,NOTIFY,MESSAGE,PRACK
+      P-Access-Network-Info: 3GPP-E-UTRAN-FDD;utran-cell-id-3gpp=0010100011a2d051
+      User-Agent: BBBBBBB IMS 5.0
+    ]]>
+  </send>
+
+  <nop next="end">
+  
+  <label id="skip_error"/>
+
+  <recv request="ACK"
+        crlf="true">
+  </recv>
+
+  <recv request="BYE">
+  </recv>
+
+  <send>
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Call-ID:]
+      [last_CSeq:]
+      [last_From:]
+      [last_To:];tag=[pid]SIPpTag01[call_number]
+      [last_Via:]
+      Server: SIP/2.0
+      Content-Length: 0
+      [last_P-Charging-Vector:]
+      Contact: <sip:[$dn]@[local_ip]:[local_port];transport=[transport]>;+g.3gpp.icsi-ref="urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel";video
+
+    ]]>
+  </send>
+
+  <!-- Keep the call open for a while in case the 200 is lost to be     -->
+  <!-- able to retransmit it if we receive the BYE again.               -->
+  <timewait milliseconds="4000"/>
+
+  <label id="end"/>
+
+</scenario>
+

--- a/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/error_caller.xml
+++ b/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/error_caller.xml
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<scenario name="Clearwater caller">
+  <send retrans="500" start_txn="invite">
+    <![CDATA[
+      INVITE sip:[field1]@[home_domain];user=phone SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: <sip:[field0]@[home_domain]>;tag=[pid]SIPpTag00[call_number]
+      To: <sip:[field1]@[home_domain]>
+      CSeq: 1 INVITE
+      Expires: 180
+      Route: <sip:[remote_ip]:5054;transport=tcp;lr;orig;service=scscf>
+      Content-Length: [len]
+      Call-Info: <sip:[local_ip]:[local_port]>;method="NOTIFY;Event=telephone-event;Duration=2000"
+      P-Charging-Function-Addresses: ccf=0.0.0.0
+      Supported: timer,precondition,sec-agree,histinfo, 100rel
+      P-Charging-Vector: icid-value=[pid]SIPpTag00[call_number]
+      Contact: <sip:[field0]@[local_ip]:[local_port]>;+g.3gpp.icsi-ref="urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel";video;+sip.instance="<urn:gsma:imei:35283606-360704-0>"
+      Content-Type: application/sdp
+      P-Early-Media: supported
+      Allow: INVITE,ACK,OPTIONS,CANCEL,BYE,UPDATE,INFO,REFER,NOTIFY,MESSAGE,PRACK
+      P-Served-User: sip:[field0]@[home_domain]
+      P-Asserted-Identity: sip:[field0]@[home_domain]
+      Security-Verify: ipsec-3gpp;q=0.1;alg=hmac-md5-96;mod=trans;ealg=aes-cbc;spi-c=265324728;spi-s=83307704;port-c=16381;port-s=5061
+      User-Agent: AAAAA IMS 4.0.0
+      Accept-Contact: *;+g.3gpp.icsi-ref="urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel"
+      Session-Expires: 1800;refresher=uac
+      Call-ID: [call_id]
+      Max-Forwards: 69
+      P-Visited-Network-ID: [home_domain]
+      Accept: application/sdp, application/dtmf-relay
+
+      v=0
+      o=AAAAAA-IMS-UE 18567144687033 18567144687033 IN IP4 [local_ip]
+      s=-
+      c=IN IP4 [local_ip]
+      t=0 0
+      m=audio 16404 RTP/AVP 116 107 118 96 0 8 111 110
+      b=AS:38
+      b=RS:375
+      b=RR:1125
+      a=inactive
+      a=rtpmap:116 AMR-WB/16000/1
+      a=rtpmap:107 AMR-WB/16000/1
+      a=rtpmap:118 AMR/8000/1
+      a=rtpmap:96 AMR/8000/1
+      a=rtpmap:111 telephone-event/16000
+      a=rtpmap:110 telephone-event/8000
+      a=rtpmap:0 PCMU/8000
+      a=rtpmap:8 PCMA/8000
+      a=fmtp:116 mode-change-capability=2; max-red=220
+      a=fmtp:107 octet-align=1;mode-change-capability=2; max-red=220
+      a=fmtp:118 mode-change-capability=2; max-red=220
+      a=fmtp:96 octet-align=1;mode-change-capability=2; max-red=220
+      a=fmtp:111 0-15
+      a=fmtp:110 0-15
+      a=curr:qos local none
+      a=curr:qos remote none
+      a=des:qos mandatory local sendrecv
+      a=des:qos optional remote sendrecv
+      a=maxptime:240
+      a=ptime:20
+
+    ]]>
+  </send>
+
+  <recv response="100" optional="true" response_txn="invite">
+  </recv>
+
+  <!-- We treat the 183 as dialog-creating, and take the Record-Route headers from there -->
+  <recv response="183" rrs="true" response_txn="invite">
+  </recv>
+
+  <send>
+    <![CDATA[
+      PRACK [next_url] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      Call-ID: [call_id]
+      From: <sip:[field0]@[home_domain]>;tag=[pid]SIPpTag00[call_number]
+      To: <sip:[field1]@[home_domain]>[peer_tag_param]
+      CSeq: 2 PRACK
+      RAck: 379992 1 INVITE
+      [routes]
+      Content-Length: 0
+      P-Charging-Vector: icid-value=[pid]SIPpTag00[call_number]
+      Security-Verify: ipsec-3gpp;q=0.1;alg=hmac-md5-96;mod=trans;ealg=aes-cbc;spi-c=265324728;spi-s=83307704;port-c=16381;port-s=5061
+      Max-Forwards: 69
+
+    ]]>
+  </send>
+
+  <recv response="200">
+  </recv>
+
+  <send>
+    <![CDATA[
+      UPDATE [next_url] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      Call-ID: [call_id]
+      From: <sip:[field0]@[home_domain]>;tag=[pid]SIPpTag00[call_number]
+      To: <sip:[field1]@[home_domain]>[peer_tag_param]
+      CSeq: 3 UPDATE
+      Contact: <sip:[field0]@[local_ip]:[local_port]>;+g.3gpp.icsi-ref="urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel";video;+sip.instance="<urn:gsma:imei:35283606-360704-0>"
+      [routes]
+      Content-Length: [len]
+      Supported: timer
+      Require: precondition
+      Proxy-Require: sec-agree
+      P-Charging-Vector: icid-value=[pid]SIPpTag00[call_number]
+      Content-Type: application/sdp
+      Security-Verify: ipsec-3gpp;q=0.1;alg=hmac-md5-96;mod=trans;ealg=aes-cbc;spi-c=265324728;spi-s=83307704;port-c=16381;port-s=5061
+      Session-Expires: 1800;refresher=uac
+      Max-Forwards: 69
+
+      v=0
+      o=SAMSUNG-IMS-UE 18567144687033 18567144687034 IN IP4 [local_ip]
+      s=-
+      c=IN IP4 [local_ip]
+      t=0 0
+      m=audio 16404 RTP/AVP 116 0 8 97 111
+      b=AS:38
+      b=RS:375
+      b=RR:1125
+      a=sendrecv
+      a=rtpmap:116 AMR-WB/16000/1
+      a=rtpmap:111 telephone-event/16000
+      a=rtpmap:0 PCMU/8000
+      a=rtpmap:8 PCMA/8000
+      a=rtpmap:97 AMR/8000
+      a=fmtp:116 mode-change-capability=2; max-red=220
+      a=fmtp:111 0-15
+      a=curr:qos local sendrecv
+      a=curr:qos remote none
+      a=des:qos mandatory local sendrecv
+      a=des:qos mandatory remote sendrecv
+      a=maxptime:240
+      a=fmtp:97 mode-change-capability=1;max-red=0
+      a=ptime:20
+
+    ]]>
+  </send>
+
+  <!--
+       The 2xx response to the UPDATE and the 180 Ringing can cross over, and
+       the UPDATE response can get confused with the 2xx response to the
+       INVITE. To solve this:
+
+       - we use 201, not 200, as the UPDATE response code (this is fine because
+         it's still in the 2xx class)
+
+       - we expect the UPDATE response as an optional message in the two places
+         we've seen it appear, before and after the 180 Ringing
+  -->
+
+  <recv response="201" optional="true">
+  </recv>
+
+  <recv response="180" rtd="true" response_txn="invite">
+  </recv>
+
+  <recv response="201" optional="true">
+  </recv>
+
+  <recv response="200" response_txn="invite">
+  </recv>
+
+  <send ack_txn="invite">
+    <![CDATA[
+      ACK [next_url] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      Call-ID: [call_id]
+      From: <sip:[field0]@[home_domain]>;tag=[pid]SIPpTag00[call_number]
+      To: <sip:[field1]@[home_domain]>[peer_tag_param]
+      CSeq: 1 ACK
+      Contact: <sip:[field0]@[local_ip]:[local_port]>;+g.3gpp.icsi-ref="urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel";video;+sip.instance="<urn:gsma:imei:35283606-360704-0>"
+      [routes]
+      Content-Length: 0
+      Max-Forwards: 69
+    ]]>
+  </send>
+
+  <!-- This delay is controlled by the -d command-line option       -->
+  <pause/>
+
+  <send retrans="500">
+    <![CDATA[
+      BYE [next_url] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      Call-ID: [call_id]
+      From: <sip:[field0]@[home_domain]>;tag=[pid]SIPpTag00[call_number]
+      To: <sip:[field1]@[home_domain]>[peer_tag_param]
+      CSeq: 159991816 BYE
+      [routes]
+      Content-Length: 0
+      P-Charging-Vector: icid-value="[pid]SIPpTag00[call_number]";orig-ioi=vmware.obu-enfield.test;term-ioi=vmware.obu-enfield.test
+      Supported: sec-agree
+      Require: sec-agree
+      Proxy-Require: sec-agree
+      P-Preferred-Identity: <sip:[field0]@[home_domain];user=phone>
+      Security-Verify: ipsec-3gpp;q=0.1;alg=hmac-md5-96;mod=trans;ealg=aes-cbc;spi-c=62539549;spi-s=244663313;port-c=16381;port-s=5061
+      P-Access-Network-Info: 3GPP-E-UTRAN-FDD;utran-cell-id-3gpp=0010100011a2d051
+      User-Agent: AAAAAA IMS 5.0
+      Max-Forwards: 69
+      Allow: INVITE,ACK,OPTIONS,CANCEL,BYE,UPDATE,INFO,REFER,NOTIFY,MESSAGE,PRACK
+
+    ]]>
+  </send>
+
+  <recv response="200" crlf="true">
+  </recv>
+
+  <!-- definition of the response time repartition table (unit is ms)   -->
+  <ResponseTimeRepartition value="2, 20, 200, 2000"/>
+
+</scenario>
+

--- a/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/error_message_receiver.xml
+++ b/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/error_message_receiver.xml
@@ -4,7 +4,7 @@
 <scenario name="Clearwater callee">
   <recv request="MESSAGE" crlf="true">
   </recv>
-  <nop next="error" chance="0.10">
+  <nop next="error" chance="0.10" />
 
   <label id="success"/>
   <send>
@@ -19,13 +19,13 @@
       Content-Length: 0
       Supported: 100rel,timer,precondition,histinfo
       [last_P-Charging-Vector:]
-      Contact: <sip:[$dn]@[local_ip]:[local_port];transport=[transport]>;+g.3gpp.icsi-ref="urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel";video
+      Contact: <sip:ipsmgw@[local_ip]:[local_port];transport=[transport]>;+g.3gpp.icsi-ref="urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel";video
       Allow: INVITE,ACK,OPTIONS,CANCEL,BYE,UPDATE,INFO,REFER,NOTIFY,MESSAGE,PRACK
       P-Access-Network-Info: 3GPP-E-UTRAN-FDD;utran-cell-id-3gpp=0010100011a2d051
       User-Agent: BBBBBBB IMS 0.0
     ]]>
   </send>
-  <nop next="end">
+  <nop next="end" />
 
   <label id="error"/>
   <send>
@@ -40,7 +40,7 @@
       Content-Length: 0
       Supported: 100rel,timer,precondition,histinfo
       [last_P-Charging-Vector:]
-      Contact: <sip:[$dn]@[local_ip]:[local_port];transport=[transport]>;+g.3gpp.icsi-ref="urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel";video
+      Contact: <sip:ipsmgw@[local_ip]:[local_port];transport=[transport]>;+g.3gpp.icsi-ref="urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel";video
       Allow: INVITE,ACK,OPTIONS,CANCEL,BYE,UPDATE,INFO,REFER,NOTIFY,MESSAGE,PRACK
       P-Access-Network-Info: 3GPP-E-UTRAN-FDD;utran-cell-id-3gpp=0010100011a2d051
       User-Agent: BBBBBBB IMS 0.0

--- a/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/error_message_receiver.xml
+++ b/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/error_message_receiver.xml
@@ -4,7 +4,9 @@
 <scenario name="Clearwater callee">
   <recv request="MESSAGE" crlf="true">
   </recv>
+  <nop next="error" chance="0.10">
 
+  <label id="success"/>
   <send>
     <![CDATA[
       SIP/2.0 200 OK
@@ -23,4 +25,26 @@
       User-Agent: BBBBBBB IMS 0.0
     ]]>
   </send>
+  <nop next="end">
+
+  <label id="error"/>
+  <send>
+    <![CDATA[
+      SIP/2.0 404 Not Found
+      [last_Call-ID:]
+      [last_CSeq:]
+      [last_From:]
+      [last_To:];tag=[pid]SIPpTag01[call_number]
+      [last_Via:]
+      Server: SIP/2.0
+      Content-Length: 0
+      Supported: 100rel,timer,precondition,histinfo
+      [last_P-Charging-Vector:]
+      Contact: <sip:[$dn]@[local_ip]:[local_port];transport=[transport]>;+g.3gpp.icsi-ref="urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel";video
+      Allow: INVITE,ACK,OPTIONS,CANCEL,BYE,UPDATE,INFO,REFER,NOTIFY,MESSAGE,PRACK
+      P-Access-Network-Info: 3GPP-E-UTRAN-FDD;utran-cell-id-3gpp=0010100011a2d051
+      User-Agent: BBBBBBB IMS 0.0
+    ]]>
+  </send>
+  <label id="end"/>
 </scenario>

--- a/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/message_receiver.xml
+++ b/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/message_receiver.xml
@@ -17,7 +17,7 @@
       Content-Length: 0
       Supported: 100rel,timer,precondition,histinfo
       [last_P-Charging-Vector:]
-      Contact: <sip:[$dn]@[local_ip]:[local_port];transport=[transport]>;+g.3gpp.icsi-ref="urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel";video
+      Contact: <sip:ipsmgw@[local_ip]:[local_port];transport=[transport]>;+g.3gpp.icsi-ref="urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel";video
       Allow: INVITE,ACK,OPTIONS,CANCEL,BYE,UPDATE,INFO,REFER,NOTIFY,MESSAGE,PRACK
       P-Access-Network-Info: 3GPP-E-UTRAN-FDD;utran-cell-id-3gpp=0010100011a2d051
       User-Agent: BBBBBBB IMS 0.0

--- a/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/message_receiver.xml
+++ b/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/message_receiver.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<scenario name="Clearwater callee">
+  <recv request="MESSAGE" crlf="true">
+  </recv>
+  <nop next="error" chance="0.10">
+
+  <label id="success"/>
+  <send>
+    <![CDATA[
+      SIP/2.0 200 OK
+      [last_Call-ID:]
+      [last_CSeq:]
+      [last_From:]
+      [last_To:];tag=[pid]SIPpTag01[call_number]
+      [last_Via:]
+      Server: SIP/2.0
+      Content-Length: 0
+      Supported: 100rel,timer,precondition,histinfo
+      [last_P-Charging-Vector:]
+      Contact: <sip:[$dn]@[local_ip]:[local_port];transport=[transport]>;+g.3gpp.icsi-ref="urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel";video
+      Allow: INVITE,ACK,OPTIONS,CANCEL,BYE,UPDATE,INFO,REFER,NOTIFY,MESSAGE,PRACK
+      P-Access-Network-Info: 3GPP-E-UTRAN-FDD;utran-cell-id-3gpp=0010100011a2d051
+      User-Agent: BBBBBBB IMS 0.0
+    ]]>
+  </send>
+  <nop next="end">
+
+  <label id="error"/>
+  <send>
+    <![CDATA[
+      SIP/2.0 404 Not Found
+      [last_Call-ID:]
+      [last_CSeq:]
+      [last_From:]
+      [last_To:];tag=[pid]SIPpTag01[call_number]
+      [last_Via:]
+      Server: SIP/2.0
+      Content-Length: 0
+      Supported: 100rel,timer,precondition,histinfo
+      [last_P-Charging-Vector:]
+      Contact: <sip:[$dn]@[local_ip]:[local_port];transport=[transport]>;+g.3gpp.icsi-ref="urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel";video
+      Allow: INVITE,ACK,OPTIONS,CANCEL,BYE,UPDATE,INFO,REFER,NOTIFY,MESSAGE,PRACK
+      P-Access-Network-Info: 3GPP-E-UTRAN-FDD;utran-cell-id-3gpp=0010100011a2d051
+      User-Agent: BBBBBBB IMS 0.0
+    ]]>
+  </send>
+  <label id="end"/>
+</scenario>

--- a/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/message_sender.xml
+++ b/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/message_sender.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE scenario SYSTEM "sipp.dtd">
 
 <scenario name="Clearwater caller">
-  <send retrans="500" start_txn="invite">
+  <send retrans="500">
     <![CDATA[
       MESSAGE sip:[field1]@[home_domain];user=phone SIP/2.0
       Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]

--- a/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/message_sender.xml
+++ b/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/message_sender.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<scenario name="Clearwater caller">
+  <send retrans="500" start_txn="invite">
+    <![CDATA[
+      MESSAGE sip:[field1]@[home_domain];user=phone SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: <sip:[field0]@[home_domain]>;tag=[pid]SIPpTag00[call_number]
+      To: <sip:[field1]@[home_domain]>
+      CSeq: 1 MESSAGE
+      Expires: 180
+      Route: <sip:[remote_ip]:5054;transport=tcp;lr;orig;service=scscf>
+      Content-Length: [len]
+      Call-Info: <sip:[local_ip]:[local_port]>;method="NOTIFY;Event=telephone-event;Duration=2000"
+      P-Charging-Function-Addresses: ccf=0.0.0.0
+      Supported: timer,precondition,sec-agree,histinfo, 100rel
+      P-Charging-Vector: icid-value=[pid]SIPpTag00[call_number]
+      Contact: <sip:[field0]@[local_ip]:[local_port]>;+g.3gpp.icsi-ref="urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel";video;+sip.instance="<urn:gsma:imei:35283606-360704-0>"
+      Content-Type: application/sdp
+      P-Early-Media: supported
+      Allow: INVITE,ACK,OPTIONS,CANCEL,BYE,UPDATE,INFO,REFER,NOTIFY,MESSAGE,PRACK
+      P-Served-User: sip:[field0]@[home_domain]
+      P-Asserted-Identity: sip:[field0]@[home_domain]
+      Security-Verify: ipsec-3gpp;q=0.1;alg=hmac-md5-96;mod=trans;ealg=aes-cbc;spi-c=265324728;spi-s=83307704;port-c=16381;port-s=5061
+      User-Agent: AAAAA IMS 4.0.0
+      Accept-Contact: *;+g.3gpp.icsi-ref="urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel"
+      Session-Expires: 1800;refresher=uac
+      Call-ID: [call_id]
+      Max-Forwards: 69
+      P-Visited-Network-ID: [home_domain]
+      Accept: application/sdp, application/dtmf-relay
+
+      v=0
+      o=AAAAAA-IMS-UE 18567144687033 18567144687033 IN IP4 [local_ip]
+      s=-
+      c=IN IP4 [local_ip]
+      t=0 0
+      m=audio 16404 RTP/AVP 116 107 118 96 0 8 111 110
+      b=AS:38
+      b=RS:375
+      b=RR:1125
+      a=inactive
+      a=rtpmap:116 AMR-WB/16000/1
+      a=rtpmap:107 AMR-WB/16000/1
+      a=rtpmap:118 AMR/8000/1
+      a=rtpmap:96 AMR/8000/1
+      a=rtpmap:111 telephone-event/16000
+      a=rtpmap:110 telephone-event/8000
+      a=rtpmap:0 PCMU/8000
+      a=rtpmap:8 PCMA/8000
+      a=fmtp:116 mode-change-capability=2; max-red=220
+      a=fmtp:107 octet-align=1;mode-change-capability=2; max-red=220
+      a=fmtp:118 mode-change-capability=2; max-red=220
+      a=fmtp:96 octet-align=1;mode-change-capability=2; max-red=220
+      a=fmtp:111 0-15
+      a=fmtp:110 0-15
+      a=curr:qos local none
+      a=curr:qos remote none
+      a=des:qos mandatory local sendrecv
+      a=des:qos optional remote sendrecv
+      a=maxptime:240
+      a=ptime:20
+    ]]>
+  </send>
+</scenario>

--- a/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/message_sender.xml
+++ b/clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/message_sender.xml
@@ -63,4 +63,7 @@
       a=ptime:20
     ]]>
   </send>
+
+  <recv response="200" />
+
 </scenario>


### PR DESCRIPTION
This branch merges a few things I've been testing together:

* Adding both a per-call and global timeout to SIPp, to stop it hanging if the core becomes unresponsive
* The changes from https://github.com/Metaswitch/clearwater-perf-utils/pull/15 to return a non-zero return code in error cases
* @AME2 's change to make SIPp return a fixed percentage of errors for call and SMS flows, controlled by a command-line option

I've tested live.