### PR TITLE
[Reviewer: Graeme] Move to Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM frolvlad/alpine-glibc
+
+RUN apk add libgcc --no-cache
+RUN apk add ncurses5-libs --no-cache
+RUN apk add python --no-cache
+
+# Some libraries aren't available in apk - copy them on directly
+COPY libraries/libtinfo.so.5 /usr/lib/
+COPY libraries/ld-linux-x86-64.so.2 /usr/lib/
+
+COPY sipp/sipp_coreonly /usr/share/clearwater/bin/
+COPY clearwater-sip-stress-coreonly.root/usr/share/clearwater/bin/run_stress /usr/share/clearwater/bin/
+COPY clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/*.xml /usr/share/clearwater/sip-stress/
+
+# Just get the help text out for now as a demo
+CMD ["/usr/share/clearwater/bin/run_stress", "-h"]
+#CMD ["/usr/share/clearwater/bin/sipp_coreonly", "-h"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,11 @@
 FROM frolvlad/alpine-glibc
 
-RUN apk add libgcc --no-cache
-RUN apk add ncurses5-libs --no-cache
 RUN apk add python --no-cache
-
-# Some libraries aren't available in apk - copy them on directly
-COPY libraries/libtinfo.so.5 /usr/lib/
-COPY libraries/ld-linux-x86-64.so.2 /usr/lib/
 
 COPY sipp/sipp_coreonly /usr/share/clearwater/bin/
 COPY clearwater-sip-stress-coreonly.root/usr/share/clearwater/bin/run_stress /usr/share/clearwater/bin/
 COPY clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/*.xml /usr/share/clearwater/sip-stress/
 
 # Just get the help text out for now as a demo
-CMD ["/usr/share/clearwater/bin/run_stress", "-h"]
-#CMD ["/usr/share/clearwater/bin/sipp_coreonly", "-h"]
+#CMD ["/usr/share/clearwater/bin/run_stress", "-h"]
+CMD ["/usr/share/clearwater/bin/sipp_coreonly", "-h"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,4 @@ COPY sipp/sipp_coreonly /usr/share/clearwater/bin/
 COPY clearwater-sip-stress-coreonly.root/usr/share/clearwater/bin/run_stress /usr/share/clearwater/bin/
 COPY clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/*.xml /usr/share/clearwater/sip-stress/
 
-# Just get the help text out for now as a demo
-#CMD ["/usr/share/clearwater/bin/run_stress", "-h"]
-CMD ["/usr/share/clearwater/bin/sipp_coreonly", "-h"]
+ENTRYPOINT ["/usr/share/clearwater/bin/run_stress"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,6 @@ RUN apk add python --no-cache
 COPY sipp/sipp_coreonly /usr/share/clearwater/bin/
 COPY clearwater-sip-stress-coreonly.root/usr/share/clearwater/bin/run_stress /usr/share/clearwater/bin/
 COPY clearwater-sip-stress-coreonly.root/usr/share/clearwater/sip-stress/*.xml /usr/share/clearwater/sip-stress/
+RUN mkdir -p /var/log/clearwater-sip-stress/
 
 ENTRYPOINT ["/usr/share/clearwater/bin/run_stress"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM frolvlad/alpine-glibc
+FROM frolvlad/alpine-glibc@sha256:88fcccb65e5a5166dde9583b0c2e7b6e418feb46697f80c1430776d431bdb494
 
 RUN apk add python --no-cache
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ sipp/configure: sipp/configure.ac
 	cd ./sipp && autoreconf -vifs
 
 sipp/Makefile: sipp/configure
-	cd ./sipp &&  LDFLAGS="-static-libgcc -static-libstdc++" ./configure
+	cd ./sipp && ./configure
 
 sipp/sipp_coreonly: sipp/Makefile sipp/src/*
 	cd ./sipp && make && mv sipp sipp_coreonly
@@ -24,14 +24,8 @@ include build-infra/cw-deb.mk
 .PHONY: deb
 deb: build deb-only
 
-libraries/libtinfo.so.5:
-	cp /lib/x86_64-linux-gnu/libtinfo.so.5 $@
-
-libraries/ld-linux-x86-64.so.2:
-	cp /lib64/ld-linux-x86-64.so.2 $@
-
 .PHONY: docker
-docker: libraries/libtinfo.so.5 libraries/ld-linux-x86-64.so.2 build
+docker:
 	 docker build -t clearwater-stresstool .
 
 .PHONY: all build test clean distclean

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ DEB_COMPONENT := clearwater-perf-utils
 DEB_NAMES := clearwater-sip-stress-coreonly
 
 build:
-	cd ./sipp && autoreconf -vifs && ./configure && make && mv sipp sipp_coreonly
+	cd ./sipp && autoreconf -vifs && LDFLAGS="-static-libgcc -static-libstdc++" ./configure && make && mv sipp sipp_coreonly
 
 clean:
 	${MAKE} -C ./sipp clean

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,16 @@ DEB_MAJOR_VERSION := 1.0${DEB_VERSION_QUALIFIER}
 DEB_COMPONENT := clearwater-perf-utils
 DEB_NAMES := clearwater-sip-stress-coreonly
 
-build:
-	cd ./sipp && autoreconf -vifs && LDFLAGS="-static-libgcc -static-libstdc++" ./configure && make && mv sipp sipp_coreonly
+build: sipp/sipp_coreonly
+
+sipp/configure: sipp/configure.ac
+	cd ./sipp && autoreconf -vifs
+
+sipp/Makefile: sipp/configure
+	cd ./sipp &&  LDFLAGS="-static-libgcc -static-libstdc++" ./configure
+
+sipp/sipp_coreonly: sipp/Makefile sipp/src/*
+	cd ./sipp && make && mv sipp sipp_coreonly
 
 clean:
 	${MAKE} -C ./sipp clean

--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,14 @@ include build-infra/cw-deb.mk
 .PHONY: deb
 deb: build deb-only
 
+libraries/libtinfo.so.5:
+	cp /lib/x86_64-linux-gnu/libtinfo.so.5 $@
+
+libraries/ld-linux-x86-64.so.2:
+	cp /lib64/ld-linux-x86-64.so.2 $@
+
+.PHONY: docker
+docker: libraries/libtinfo.so.5 libraries/ld-linux-x86-64.so.2 build
+	 docker build -t clearwater-stresstool .
+
 .PHONY: all build test clean distclean


### PR DESCRIPTION
This:

* adds a Dockerfile
* makes SIPp more suitable for running in containers by linking it statically and speeding up the build process (minimising unnecessary rebuilds)