### PR TITLE
[Reviewer: Ben] IPv6 support for SIPp

### DIFF
--- a/clearwater-sip-stress-coreonly.root/usr/share/clearwater/bin/run_stress
+++ b/clearwater-sip-stress-coreonly.root/usr/share/clearwater/bin/run_stress
@@ -32,7 +32,7 @@
 # as those licenses appear in the file LICENSE-OPENSSL.
 
 from random import shuffle
-from subprocess import Popen
+from subprocess import Popen, check_output
 from csv import DictReader, Dialect
 from datetime import datetime
 import csv
@@ -156,6 +156,8 @@ invite_csv.flush()
 
 null = open("/dev/null", "w+")
 
+ipv6_addr = check_output("ifconfig eth0 | grep inet6 | grep Global | grep -Eo \"[a-f0-9]{4}:[a-f0-9:]+\" | head -n 1", shell=True).strip()
+
 common_args = ["-default_behaviors", "all,-bye",
                # Reconnect up to 2,000 times if we get disconnected (e.g. due
                # to Sprout connection recycling) - this was chosen as an
@@ -168,7 +170,8 @@ common_args = ["-default_behaviors", "all,-bye",
                # Jenkins), it uses 100% CPU unless you pass the -nostdin flag.
                "-nostdin",
                "-recv_timeout", "20s",
-               "-t", "t1"]
+               "-t", "t1",
+               "-i", ipv6_addr]
 
 common_originating_args = common_args + ["-key", "home_domain", args.domain]
 

--- a/clearwater-sip-stress-coreonly.root/usr/share/clearwater/bin/run_stress
+++ b/clearwater-sip-stress-coreonly.root/usr/share/clearwater/bin/run_stress
@@ -87,6 +87,7 @@ parser.add_argument('--target-latency', help='Target average latency.  The scrip
 parser.add_argument('--target-call-success-rate', help='Target call success rate.  The script will fail if the actual rate is lower.', type=float, default=100.0)
 parser.add_argument('--target-reg-success-rate', help='Target registration success rate.  The script will fail if the actual rate is lower.', type=float, default=100.0)
 parser.add_argument('--ccf', help='IP or hostname of the CCF to use.', type=str, default="0.0.0.0")
+parser.add_argument('--ipv6', help="Send traffic to an IPv6 system", action='store_const', const=True, default=False)
 
 args = parser.parse_args()
 
@@ -156,8 +157,6 @@ invite_csv.flush()
 
 null = open("/dev/null", "w+")
 
-ipv6_addr = check_output("ifconfig eth0 | grep inet6 | grep Global | grep -Eo \"[a-f0-9]{4}:[a-f0-9:]+\" | head -n 1", shell=True).strip()
-
 common_args = ["-default_behaviors", "all,-bye",
                # Reconnect up to 2,000 times if we get disconnected (e.g. due
                # to Sprout connection recycling) - this was chosen as an
@@ -170,8 +169,16 @@ common_args = ["-default_behaviors", "all,-bye",
                # Jenkins), it uses 100% CPU unless you pass the -nostdin flag.
                "-nostdin",
                "-recv_timeout", "20s",
-               "-t", "t1",
-               "-i", ipv6_addr]
+               "-t", "t1"]
+if args.ipv6:
+    # To send traffic to an IPv6 system, we need to pass SIPp the system's IPv6
+    # address. There's no nice, portable way to do this, so parse ifconfig's
+    # output.
+    #
+    # We could use https://pypi.python.org/pypi/netifaces here, but that would
+    # introduce an extra dependency.
+    ipv6_addr = check_output("ifconfig eth0 | grep inet6 | grep Global | grep -Eo \"[a-f0-9]{4}:[a-f0-9:]+\" | head -n 1", shell=True).strip()
+    common_args += ["-i", ipv6_addr]
 
 common_originating_args = common_args + ["-key", "home_domain", args.domain]
 


### PR DESCRIPTION
Sending to you as you've probably done something similar before...

I wanted to run stress against an IPv6 deployment, so I've added a `--ipv6` option to `run_stress` which figures out the IPv6 address and passes it to SIPp.